### PR TITLE
fix: allow card socials to be undefined

### DIFF
--- a/src/components/SessionCard/index.tsx
+++ b/src/components/SessionCard/index.tsx
@@ -95,23 +95,25 @@ export function SessionCard({
               )}
             </Text>
           </details>
-          <div className={styles.socialLinks}>
-            {socials.map(({ icon, href }) => (
-              <Link
-                className={styles.socialLink}
-                href={href}
-                key={href}
-                target="_blank"
-              >
-                <Image
-                  alt={`${by}'s ${icon}`}
-                  height={32}
-                  src={`/icons/${icon}.png`}
-                  width={32}
-                />
-              </Link>
-            ))}
-          </div>
+          {socials && (
+            <div className={styles.socialLinks}>
+              {socials.map(({ icon, href }) => (
+                <Link
+                  className={styles.socialLink}
+                  href={href}
+                  key={href}
+                  target="_blank"
+                >
+                  <Image
+                    alt={`${by}'s ${icon}`}
+                    height={32}
+                    src={`/icons/${icon}.png`}
+                    width={32}
+                  />
+                </Link>
+              ))}
+            </div>
+          )}
         </div>
       </Card>
     </div>

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -36,7 +36,7 @@ export interface EventSocial {
 export interface EventSession {
   by: string;
   description?: string[];
-  socials: EventSocial[];
+  socials?: EventSocial[];
   title: string;
 }
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #26
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/halfstackconf-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/halfstackconf-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

* Updates the types for socials to be `?:` optional
* Only renders the `div.socialLinks` if they exist