### PR TITLE
fix: corrected CSS styles for Tito widget

### DIFF
--- a/src/components/TicketsOffer/useTitoWidget.module.css
+++ b/src/components/TicketsOffer/useTitoWidget.module.css
@@ -1,5 +1,12 @@
 /* stylelint-disable */
-.titoWidget,
-.titoWidget :global(.tito-widget) {
+.titoWidget {
   height: 100%;
+}
+
+.titoWidget :global(.tito-widget) * {
+  color: var(--color-primary);
+}
+
+.titoWidget :global(.tito-widget .tito-submit) {
+  background: var(--color-primary);
 }

--- a/src/components/TicketsOffer/useTitoWidget.tsx
+++ b/src/components/TicketsOffer/useTitoWidget.tsx
@@ -28,7 +28,7 @@ export function useTitoWidget(event: string) {
 
     const script = document.createElement("script");
     script.setAttribute("async", "async");
-    script.setAttribute("src", "https://js.tito.io/v2");
+    script.setAttribute("src", "https://js.tito.io/v2/with/inline");
     script.addEventListener("load", () => {
       setLoaded(true);
     });
@@ -36,9 +36,13 @@ export function useTitoWidget(event: string) {
     added = true;
   }, []);
 
-  return loaded ? (
-    <tito-widget className={styles.titoWidget} event={event}></tito-widget>
-  ) : (
-    <div>loading...</div>
+  return (
+    <div className={styles.titoWidget}>
+      {loaded ? (
+        <tito-widget event={event}></tito-widget>
+      ) : (
+        <div>loading...</div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to halfstackconf-next! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #47
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/halfstackconf-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/halfstackconf-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Makes Tito widget [`with/inline` per the v2 docs](https://ti.to/docs/api/widget#tito-widget-v2-form-styles) and touches up the CSS styles to apply to its contents.

![Screenshot of /charlotte/tickets with green styled tickets text and submit button](https://user-images.githubusercontent.com/3335181/221086849-586e441f-d757-4504-8b28-47d291a768f6.png)

