### PR TITLE
fix: corrected image stretching styles

### DIFF
--- a/src/components/EventFooter/index.tsx
+++ b/src/components/EventFooter/index.tsx
@@ -32,10 +32,6 @@ export function EventFooter({ slug }: EventFooterProps) {
           className={styles.cityscapeImage}
           height={150}
           src={`/events/${slug}/skyline.png`}
-          style={{
-            maxWidth: "100%",
-            height: "auto",
-          }}
           width={350}
         />
       </div>
@@ -49,15 +45,7 @@ export function EventFooter({ slug }: EventFooterProps) {
               rel="noreferrer"
               target="_blank"
             >
-              <Image
-                alt={`${alt} logo`}
-                className={styles.icon}
-                src={src}
-                style={{
-                  maxWidth: "100%",
-                  height: "auto",
-                }}
-              />
+              <Image alt={`${alt} logo`} className={styles.icon} src={src} />
             </a>
           ))}
         </div>

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -47,10 +47,6 @@ export function Footer() {
               className={styles.cityscapeImage}
               sizes="10vw"
               src={src}
-              style={{
-                maxWidth: "100%",
-                height: "auto",
-              }}
             />
           </Link>
         ))}
@@ -64,15 +60,7 @@ export function Footer() {
             rel="noreferrer"
             target="_blank"
           >
-            <Image
-              alt={`${alt} logo`}
-              className={styles.icon}
-              src={src}
-              style={{
-                maxWidth: "100%",
-                height: "auto",
-              }}
-            />
+            <Image alt={`${alt} logo`} className={styles.icon} src={src} />
           </a>
         ))}
       </div>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -44,15 +44,7 @@ export function Header({
     <header className={clsx(styles.header, className)}>
       <div className={styles.contents}>
         <Link href="/">
-          <Image
-            alt="HalfStack"
-            className={styles.logo}
-            src={logo}
-            style={{
-              maxWidth: "100%",
-              height: "auto",
-            }}
-          />
+          <Image alt="HalfStack" className={styles.logo} src={logo} />
         </Link>
         <nav className={styles.links}>
           {links.map(([children, href]) => (

--- a/src/components/Index/Newsletter/index.tsx
+++ b/src/components/Index/Newsletter/index.tsx
@@ -65,10 +65,6 @@ export function Newsletter() {
               className={styles.submitIcon}
               sizes="3.5rem"
               src={checkButton}
-              style={{
-                maxWidth: "100%",
-                height: "auto",
-              }}
             />
           </button>
         </form>

--- a/src/components/LabeledIcons/index.tsx
+++ b/src/components/LabeledIcons/index.tsx
@@ -25,10 +25,6 @@ export function LabeledIcons({ className, icons }: LabeledIconsProps) {
             className={styles.icon}
             height={110}
             src={icon}
-            style={{
-              maxWidth: "100%",
-              height: "auto",
-            }}
             width={110}
           />
           <Text as="div" className={styles.label}>

--- a/src/components/SessionCard/index.tsx
+++ b/src/components/SessionCard/index.tsx
@@ -108,10 +108,6 @@ export function SessionCard({
                     alt={`${by}'s ${icon}`}
                     height={32}
                     src={`/icons/${icon}.png`}
-                    style={{
-                      maxWidth: "100%",
-                      height: "auto",
-                    }}
                     width={32}
                   />
                 </Link>

--- a/src/components/SplitPromo/index.tsx
+++ b/src/components/SplitPromo/index.tsx
@@ -15,16 +15,7 @@ export function SplitPromo({ className, description, src }: SplitPromoProps) {
   return (
     <Columns className={clsx(styles.splitPromo, className)}>
       <div className={styles.imageArea}>
-        <Image
-          alt=""
-          className={styles.image}
-          fill
-          src={src}
-          style={{
-            maxWidth: "100%",
-            height: "auto",
-          }}
-        />
+        <Image alt="" className={styles.image} fill src={src} />
       </div>
       <div className={styles.description}>
         {description.map((child) => (

--- a/src/components/SponsorshipPackages/index.tsx
+++ b/src/components/SponsorshipPackages/index.tsx
@@ -65,16 +65,7 @@ export const SponsorshipPackages = ({
     <InvertedArea className={styles.sponsorshipPackages}>
       <BodyArea>
         <Text as="h2" className={styles.h2} fontSize="extra-large">
-          <Image
-            alt=""
-            height={96}
-            src="/icons/gift.png"
-            style={{
-              maxWidth: "100%",
-              height: "auto",
-            }}
-            width={96}
-          />
+          <Image alt="" height={96} src="/icons/gift.png" width={96} />
           Packages
         </Text>
         <div className={styles.contents}>

--- a/src/components/TintedImage/index.tsx
+++ b/src/components/TintedImage/index.tsx
@@ -11,16 +11,7 @@ export function TintedImage({ className, src }: TintedImageProps) {
   return (
     <div className={className}>
       <div className={styles.overlay} />
-      <Image
-        alt=""
-        className={styles.image}
-        fill
-        src={src}
-        style={{
-          maxWidth: "100%",
-          height: "auto",
-        }}
-      />
+      <Image alt="" className={styles.image} fill src={src} />
     </div>
   );
 }


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #54
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/halfstackconf-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/halfstackconf-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The Next.js codemods added these in #51. Different CSS ordering on production deployments meant they only caused bugs there, not in local dev servers. _sigh_ 