### PR TITLE
fix: switch now4real embed to floating

### DIFF
--- a/src/components/Now4Real.tsx
+++ b/src/components/Now4Real.tsx
@@ -12,9 +12,7 @@ declare global {
   }
 }
 
-const containerId = "now4real-container";
-
-export function Now4Real() {
+export function useNow4Real() {
   useEffect(() => {
     if (window.now4real) {
       return;
@@ -27,7 +25,6 @@ export function Now4Real() {
         widget: {
           color_1: "#22366E",
           color_2: "#ffffff",
-          container: containerId,
         },
       },
     };
@@ -38,29 +35,4 @@ export function Now4Real() {
     n4r.type = "text/javascript";
     document.body.appendChild(n4r);
   }, []);
-
-  return (
-    <div
-      id={containerId}
-      ref={(div) => {
-        if (!div) {
-          return;
-        }
-
-        const observer = new MutationObserver(() => {
-          const iframe = div.querySelector("iframe");
-          if (!iframe) {
-            return;
-          }
-
-          // By default, Now4Real doesn't add a title to its iframes.
-          // https://dequeuniversity.com/rules/axe/4.6/frame-title
-          iframe.title = "Now4Real Embed";
-          observer.disconnect();
-        });
-
-        observer.observe(div, { childList: true });
-      }}
-    />
-  );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,15 +2,12 @@ import "./_app.css";
 
 import type { AppProps } from "next/app";
 
-import { Now4Real } from "~/components/Now4Real";
+import { useNow4Real } from "~/components/Now4Real";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return (
-    <>
-      <Component {...pageProps} />
-      <Now4Real />
-    </>
-  );
+  useNow4Real();
+
+  return <Component {...pageProps} />;
 }
 
 export default MyApp;


### PR DESCRIPTION
## Overview

Thanks to some advice from now4real guru Alessandro, I now know assigning a `containerId` was unnecessary. It switched the embed from free-floating to taking up the container.

Also removes the now-unnecessary iframe title override. They fixed it last week.
