### PR TITLE
docs: explained event management, with more permissive data

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,50 @@ pnpm install
 pm2 start "pnpm production"
 ```
 
+## Events Management
+
+Events are all stored in `src/data` as `.json` files.
+
+- [`src/data/events.json`](./src/data/events.json) contains the array of event lines that are listed on the homepage
+- [The `src/data/events/ directory](./src/data/events) contains a directory for each of those event lines, each of which contains:
+  - `current.json`: Data for the current event shown on and linked to by the homepage
+  - `default.json`: Default data for the current event and all historical events in that line
+  - `20**.json`: Files for each past year in that event line
+
+Event pages read in that data by utilities in [`src/data/index.ts`](./src/data/index.ts).
+See [`src/data/types.ts`](./src/data/types.ts) for the precise data formats expected.
+
+### Adding a New Event Date
+
+Adding a new year for an event generally involves changing the event's current year to a historical event, and adding a new current event:
+
+1. Copy the event's `current.json` to a file with current year (e.g. `2023.json`)
+2. Create a new blank `current.json` copying over any data that's the same year-to-year (most likely: `"description"` and `"geolocation"`)
+3. Copy over any fields from the past event data to the current event data as they become known
+
+#### Adding Event Sessions
+
+Speaker speaker are stored in order in the event's `sessions` data.
+Each `"by"` field should be given a _`kebab-case.jpg`_ image in `public/speakers`.
+
+#### Adding Event Sponsors
+
+Event sponsors are stored under the `"sponsors"` data, within their tier: `"complete"`, `"large"`, `"medium"`, or `"small"`.
+Each should have a `"src"` with a path starting with `/logos/` that points to an image under `public/images/`.
+
+If the event's sponsorship is available, it should have a `"sponsorship"` object with the property `"available": true` in its event data.
+
+### Adding a New Event Line
+
+1. Copy and paste an exting event folder into the new slug for the event
+2. Delete any historical data from the folder
+3. Modify the event's `default.json` and `current.json` for the new event's details
+4. Add the event's slug to `src/data/events.json`
+5. Add branding images and styles for the new event line:
+   1. In `src/components/EventTheme/index.module.css`, add a new class selector for the event slug
+   1. Create a new folder for the event's images under `public/events/`
+   1. For each of the images referenced in those styles, add it under that new folder
+
 ## Contributing
 
 See [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md).

--- a/src/components/EventCard/index.tsx
+++ b/src/components/EventCard/index.tsx
@@ -21,6 +21,7 @@ export function EventCard({
   event: { catchphrase, date, description, name, slug },
   direction,
 }: EventCardProps) {
+  const catchyText = catchphrase ?? description?.join(" ");
   return (
     <Card
       as={Link}
@@ -37,9 +38,11 @@ export function EventCard({
         <Text as="div" className={styles.date}>
           {date}
         </Text>
-        <Text as="div" className={styles.description}>
-          {catchphrase ?? description.join(" ")}
-        </Text>
+        {catchyText && (
+          <Text as="div" className={styles.description}>
+            {catchyText}
+          </Text>
+        )}
       </div>
       <div className={styles.thumbnail} />
     </Card>

--- a/src/components/SplitPromo/index.tsx
+++ b/src/components/SplitPromo/index.tsx
@@ -7,7 +7,7 @@ import styles from "./index.module.css";
 
 export interface SplitPromoProps {
   className?: string;
-  description: string[];
+  description?: string[];
   src: string;
 }
 
@@ -17,11 +17,13 @@ export function SplitPromo({ className, description, src }: SplitPromoProps) {
       <div className={styles.imageArea}>
         <Image alt="" className={styles.image} fill src={src} />
       </div>
-      <div className={styles.description}>
-        {description.map((child) => (
-          <Text key={child}>{child}</Text>
-        ))}
-      </div>
+      {description && (
+        <div className={styles.description}>
+          {description.map((child) => (
+            <Text key={child}>{child}</Text>
+          ))}
+        </div>
+      )}
     </Columns>
   );
 }

--- a/src/components/TintedImage/index.tsx
+++ b/src/components/TintedImage/index.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { useState } from "react";
 
 import styles from "./index.module.css";
 
@@ -8,10 +9,20 @@ export interface TintedImageProps {
 }
 
 export function TintedImage({ className, src }: TintedImageProps) {
+  const [errored, setErrored] = useState(false);
+
   return (
     <div className={className}>
       <div className={styles.overlay} />
-      <Image alt="" className={styles.image} fill src={src} />
+      {errored ? null : (
+        <Image
+          alt=""
+          className={styles.image}
+          fill
+          onError={() => setErrored(true)}
+          src={src}
+        />
+      )}
     </div>
   );
 }

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -50,11 +50,11 @@ export interface EventDataCurrent extends EventDataBase {
   afterparty?: string;
   catchphrase?: string;
   code: string;
-  description: string[];
+  description?: string[];
   faqs?: [string, string][];
-  geolocation: EventGeoLocation;
+  geolocation?: EventGeoLocation;
   layoffs?: string;
-  location: string;
+  location?: string;
   packet?: string;
   schedule: string;
   sessions?: EventSession[];

--- a/src/pages/[event]/index.tsx
+++ b/src/pages/[event]/index.tsx
@@ -61,7 +61,7 @@ export default function Event({
       <EventSummary
         afterparty={afterparty}
         date={date}
-        location={location}
+        location={location ?? name}
         trailer={trailer}
       />
 
@@ -115,7 +115,7 @@ export default function Event({
 
       {sponsors && <SponsorStacksList {...sponsors} slug={slug} />}
 
-      <FindUs geolocation={geolocation} slug={slug} />
+      {geolocation && <FindUs geolocation={geolocation} slug={slug} />}
 
       <EventFooter slug={slug} />
     </EventTheme>

--- a/src/pages/[event]/spon.tsx
+++ b/src/pages/[event]/spon.tsx
@@ -48,7 +48,7 @@ export default function Spon({
       <EventSummary
         afterparty={afterparty}
         date={date}
-        location={location}
+        location={location ?? name}
         trailer={trailer}
       />
 


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #21
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/halfstackconf-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/halfstackconf-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Added a set of explanations for common event tasks to `README.md`. I tried to stick to high-level ideas and not dive too much into field specifics.

Also made some more pieces of data for events tolerate not being provided. Easier to mess around events this way.