### PR TITLE
fix(FindUs): Water matches event's theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pm2 start "pnpm production"
 
 Events are all stored in `src/data` as `.json` files.
 
-- [`src/data/events.json`](./src/data/events.json) contains the array of event lines that are listed on the homepage
+- [`src/data/events/index.ts`](./src/data/events/index.ts) contains the array of event lines that are listed on the homepage
 - [The `src/data/events/ directory](./src/data/events) contains a directory for each of those event lines, each of which contains:
   - `current.json`: Data for the current event shown on and linked to by the homepage
   - `default.json`: Default data for the current event and all historical events in that line
@@ -148,7 +148,7 @@ If the event's sponsorship is available, it should have a `"sponsorship"` object
 1. Copy and paste an exting event folder into the new slug for the event
 2. Delete any historical data from the folder
 3. Modify the event's `default.json` and `current.json` for the new event's details
-4. Add the event's slug to `src/data/events.json`
+4. Add the event's slug to `src/data/events/index.ts`
 5. Add branding images and styles for the new event line:
    1. In `src/components/EventTheme/index.module.css`, add a new class selector for the event slug
    1. Create a new folder for the event's images under `public/events/`

--- a/src/components/EventFooter/index.tsx
+++ b/src/components/EventFooter/index.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 
-import { EventName } from "~/data/types";
+import { EventSlug } from "~/data/types";
 
 import { BodyArea } from "../BodyArea";
 import { CopyrightFooter } from "../CopyrightFooter";
@@ -22,7 +22,7 @@ const icons = [
 ] as const;
 
 export interface EventFooterProps {
-  slug: EventName;
+  slug: EventSlug;
 }
 
 export function EventFooter({ slug }: EventFooterProps) {

--- a/src/components/EventFooter/index.tsx
+++ b/src/components/EventFooter/index.tsx
@@ -1,5 +1,7 @@
 import Image from "next/image";
 
+import { EventName } from "~/data/types";
+
 import { BodyArea } from "../BodyArea";
 import { CopyrightFooter } from "../CopyrightFooter";
 import { RoundLink } from "../RoundLink";
@@ -20,7 +22,7 @@ const icons = [
 ] as const;
 
 export interface EventFooterProps {
-  slug: string;
+  slug: EventName;
 }
 
 export function EventFooter({ slug }: EventFooterProps) {

--- a/src/components/EventHeader/index.tsx
+++ b/src/components/EventHeader/index.tsx
@@ -1,9 +1,9 @@
-import { EventName } from "~/data/types";
+import { EventSlug } from "~/data/types";
 
 import { Header } from "../Header";
 
 export interface EventHeaderProps {
-  slug: EventName;
+  slug: EventSlug;
 }
 
 export function EventHeader({ slug }: EventHeaderProps) {

--- a/src/components/EventHeader/index.tsx
+++ b/src/components/EventHeader/index.tsx
@@ -1,7 +1,9 @@
+import { EventName } from "~/data/types";
+
 import { Header } from "../Header";
 
 export interface EventHeaderProps {
-  slug: string;
+  slug: EventName;
 }
 
 export function EventHeader({ slug }: EventHeaderProps) {

--- a/src/components/EventSchedule/index.tsx
+++ b/src/components/EventSchedule/index.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { EventName } from "~/data/types";
+
 import { BodyArea } from "../BodyArea";
 import { Text } from "../Text";
 import styles from "./index.module.css";
@@ -7,7 +9,7 @@ import styles from "./index.module.css";
 export interface EventScheduleProps {
   packet: string | undefined;
   schedule: string;
-  slug: string;
+  slug: EventName;
 }
 
 export function EventSchedule({ packet, schedule, slug }: EventScheduleProps) {

--- a/src/components/EventSchedule/index.tsx
+++ b/src/components/EventSchedule/index.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 
-import { EventName } from "~/data/types";
+import { EventSlug } from "~/data/types";
 
 import { BodyArea } from "../BodyArea";
 import { Text } from "../Text";
@@ -9,7 +9,7 @@ import styles from "./index.module.css";
 export interface EventScheduleProps {
   packet: string | undefined;
   schedule: string;
-  slug: EventName;
+  slug: EventSlug;
 }
 
 export function EventSchedule({ packet, schedule, slug }: EventScheduleProps) {

--- a/src/components/EventTheme/colors.tsx
+++ b/src/components/EventTheme/colors.tsx
@@ -1,0 +1,67 @@
+export default {
+  charlotte: {
+    "color-backdrop-subtle": "#72be8d",
+    "color-faint": "#abd9ba",
+    "color-primary": "#1e7640",
+    "color-primary-dark": "#154427",
+    "color-primary-light": "#afe9c4",
+  },
+  london: {
+    "color-backdrop-subtle": "#2a45a3",
+    "color-faint": "#ebf0f7",
+    "color-primary": "#22366e",
+    "color-primary-dark": "#19223a",
+    "color-primary-light": "#7083c6",
+  },
+  newquay: {
+    "color-backdrop-subtle": "#262262",
+    "color-faint": "#e4e4ec",
+    "color-primary": "#262261",
+    "color-primary-dark": "#252347",
+    "color-primary-light": "#5a5880",
+  },
+  newyork: {
+    "color-backdrop-subtle": "#2f2d2e",
+    "color-faint": "#cbcbcb",
+    "color-primary": "#2f2d2e",
+    "color-primary-dark": "#151414",
+    "color-primary-light": "#5b5457",
+  },
+  phoenix: {
+    "color-backdrop-subtle": "#524ca6",
+    "color-faint": "#e4e4ec",
+    "color-primary": "#262262",
+    "color-primary-dark": "#252347",
+    "color-primary-light": "#736ccd",
+  },
+  telaviv: {
+    "color-backdrop-subtle": "#5073df",
+    "color-faint": "#9cb0d9",
+    "color-primary": "#324d9c",
+    "color-primary-dark": "#28396a",
+    "color-primary-light": "#809bed",
+  },
+  vienna: {
+    "color-backdrop-subtle": "#e78689",
+    "color-faint": "#fadddf",
+    "color-primary": "#b41c21",
+    "color-primary-dark": "#8b0f13",
+    "color-primary-light": "#f3a7a9",
+  },
+  belgrade: {
+    "color-backdrop-subtle": "#e1ff99",
+    "color-faint": "#e1ff99",
+    "color-primary": "#7aa11c",
+    "color-primary-dark": "#304007",
+    "color-primary-light": "#e1ff99",
+  },
+} as Record<
+  string,
+  {
+    "color-backdrop-subtle": string;
+    "color-faint": string;
+    "color-primary": string;
+    "color-primary-dark": string;
+    "color-primary-light": string;
+  }
+>;

--- a/src/components/EventTheme/colors.tsx
+++ b/src/components/EventTheme/colors.tsx
@@ -1,6 +1,6 @@
-import { EventName } from "~/data/types";
+import { EventSlug } from "~/data/types";
 
-interface EventColors {
+export interface EventColors {
   "color-backdrop-subtle": string;
   "color-faint": string;
   "color-primary": string;
@@ -8,7 +8,7 @@ interface EventColors {
   "color-primary-light": string;
 }
 
-const colors: Record<EventName, EventColors> = {
+export const colors: Record<EventSlug, EventColors> = {
   charlotte: {
     "color-backdrop-subtle": "#72be8d",
     "color-faint": "#abd9ba",
@@ -73,4 +73,3 @@ const colors: Record<EventName, EventColors> = {
     "color-primary-light": "#e1ff99",
   },
 };
-export default colors;

--- a/src/components/EventTheme/colors.tsx
+++ b/src/components/EventTheme/colors.tsx
@@ -1,4 +1,14 @@
-export default {
+import { EventName } from "~/data/types";
+
+interface EventColors {
+  "color-backdrop-subtle": string;
+  "color-faint": string;
+  "color-primary": string;
+  "color-primary-dark": string;
+  "color-primary-light": string;
+}
+
+const colors: Record<EventName, EventColors> = {
   charlotte: {
     "color-backdrop-subtle": "#72be8d",
     "color-faint": "#abd9ba",
@@ -7,6 +17,13 @@ export default {
     "color-primary-light": "#afe9c4",
   },
   london: {
+    "color-backdrop-subtle": "#2a45a3",
+    "color-faint": "#ebf0f7",
+    "color-primary": "#22366e",
+    "color-primary-dark": "#19223a",
+    "color-primary-light": "#7083c6",
+  },
+  "london-on-the-thames": {
     "color-backdrop-subtle": "#2a45a3",
     "color-faint": "#ebf0f7",
     "color-primary": "#22366e",
@@ -55,13 +72,5 @@ export default {
     "color-primary-dark": "#304007",
     "color-primary-light": "#e1ff99",
   },
-} as Record<
-  string,
-  {
-    "color-backdrop-subtle": string;
-    "color-faint": string;
-    "color-primary": string;
-    "color-primary-dark": string;
-    "color-primary-light": string;
-  }
->;
+};
+export default colors;

--- a/src/components/EventTheme/index.tsx
+++ b/src/components/EventTheme/index.tsx
@@ -1,17 +1,17 @@
 import clsx from "clsx";
 
-import { EventName } from "~/data/types";
+import { EventSlug } from "~/data/types";
 
-import colors from "./colors";
+import { colors } from "./colors";
 import styles from "./index.module.css";
 
 export interface EventThemeProps {
   children: React.ReactNode;
-  event: EventName;
+  event: EventSlug;
 }
 
 export interface EventColorProps {
-  event: EventName;
+  event: EventSlug;
 }
 
 export function EventTheme({ children, event }: EventThemeProps) {
@@ -20,6 +20,6 @@ export function EventTheme({ children, event }: EventThemeProps) {
   );
 }
 
-export function useEventColors(event: EventName) {
+export function useEventColors(event: EventSlug) {
   return colors[event];
 }

--- a/src/components/EventTheme/index.tsx
+++ b/src/components/EventTheme/index.tsx
@@ -1,15 +1,17 @@
 import clsx from "clsx";
 
+import { EventName } from "~/data/types";
+
 import colors from "./colors";
 import styles from "./index.module.css";
 
 export interface EventThemeProps {
   children: React.ReactNode;
-  event: string;
+  event: EventName;
 }
 
 export interface EventColorProps {
-  event: string;
+  event: EventName;
 }
 
 export function EventTheme({ children, event }: EventThemeProps) {
@@ -18,6 +20,6 @@ export function EventTheme({ children, event }: EventThemeProps) {
   );
 }
 
-export function EventColors({ event }: EventColorProps) {
+export function useEventColors(event: EventName) {
   return colors[event];
 }

--- a/src/components/EventTheme/index.tsx
+++ b/src/components/EventTheme/index.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 
+import colors from "./colors";
 import styles from "./index.module.css";
 
 export interface EventThemeProps {
@@ -7,8 +8,16 @@ export interface EventThemeProps {
   event: string;
 }
 
+export interface EventColorProps {
+  event: string;
+}
+
 export function EventTheme({ children, event }: EventThemeProps) {
   return (
     <div className={clsx(styles.eventTheme, styles[event])}>{children}</div>
   );
+}
+
+export function EventColors({ event }: EventColorProps) {
+  return colors[event];
 }

--- a/src/components/FindUs/createMapOptions.ts
+++ b/src/components/FindUs/createMapOptions.ts
@@ -1,4 +1,8 @@
-export const createMapOptions = () => ({
+interface createMapArguments {
+  waterColor: string;
+}
+
+export const createMapOptions = ({ waterColor }: createMapArguments) => ({
   mapTypeControl: false,
   scrollwheel: false,
   streetViewControl: false,
@@ -73,9 +77,7 @@ export const createMapOptions = () => ({
       featureType: "water",
       elementType: "all",
       stylers: [
-        {
-          color: "#072a74",
-        },
+        { color: waterColor },
         {
           visibility: "on",
         },

--- a/src/components/FindUs/createMapOptions.ts
+++ b/src/components/FindUs/createMapOptions.ts
@@ -1,8 +1,8 @@
-interface createMapArguments {
+interface CreateMapArguments {
   waterColor: string;
 }
 
-export const createMapOptions = ({ waterColor }: createMapArguments) => ({
+export const createMapOptions = ({ waterColor }: CreateMapArguments) => ({
   mapTypeControl: false,
   scrollwheel: false,
   streetViewControl: false,

--- a/src/components/FindUs/index.tsx
+++ b/src/components/FindUs/index.tsx
@@ -2,7 +2,7 @@ import { GoogleMap, useJsApiLoader } from "@react-google-maps/api";
 import { useCallback, useMemo } from "react";
 
 import { useEventColors } from "~/components/EventTheme";
-import { EventGeoLocation, EventName } from "~/data/types";
+import { EventGeoLocation, EventSlug } from "~/data/types";
 
 import { Text } from "../Text";
 import { createMapOptions } from "./createMapOptions";
@@ -10,7 +10,7 @@ import styles from "./index.module.css";
 
 export interface FindUsProps {
   geolocation: EventGeoLocation;
-  slug: EventName;
+  slug: EventSlug;
 }
 
 const containerStyle = {

--- a/src/components/FindUs/index.tsx
+++ b/src/components/FindUs/index.tsx
@@ -1,7 +1,8 @@
 import { GoogleMap, useJsApiLoader } from "@react-google-maps/api";
 import { useCallback, useMemo } from "react";
 
-import { EventGeoLocation } from "~/data/types";
+import { useEventColors } from "~/components/EventTheme";
+import { EventGeoLocation, EventName } from "~/data/types";
 
 import { Text } from "../Text";
 import { createMapOptions } from "./createMapOptions";
@@ -9,8 +10,7 @@ import styles from "./index.module.css";
 
 export interface FindUsProps {
   geolocation: EventGeoLocation;
-  slug: string;
-  waterColor: string;
+  slug: EventName;
 }
 
 const containerStyle = {
@@ -18,7 +18,7 @@ const containerStyle = {
   height: "400px",
 };
 
-export function FindUs({ geolocation, slug, waterColor }: FindUsProps) {
+export function FindUs({ geolocation, slug }: FindUsProps) {
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
     googleMapsApiKey: "AIzaSyAF3YU1nrEkOHd_kmrvTmOtlyTQMjPmRlk",
@@ -28,6 +28,9 @@ export function FindUs({ geolocation, slug, waterColor }: FindUsProps) {
     () => ({ lat: geolocation[0], lng: geolocation[1] }),
     [geolocation]
   );
+
+  const colors = useEventColors(slug);
+  const waterColor = colors["color-primary-light"];
 
   const onLoad = useCallback(
     (map: google.maps.Map) => {

--- a/src/components/FindUs/index.tsx
+++ b/src/components/FindUs/index.tsx
@@ -10,6 +10,7 @@ import styles from "./index.module.css";
 export interface FindUsProps {
   geolocation: EventGeoLocation;
   slug: string;
+  waterColor: string;
 }
 
 const containerStyle = {
@@ -17,7 +18,7 @@ const containerStyle = {
   height: "400px",
 };
 
-export function FindUs({ geolocation, slug }: FindUsProps) {
+export function FindUs({ geolocation, slug, waterColor }: FindUsProps) {
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
     googleMapsApiKey: "AIzaSyAF3YU1nrEkOHd_kmrvTmOtlyTQMjPmRlk",
@@ -30,7 +31,7 @@ export function FindUs({ geolocation, slug }: FindUsProps) {
 
   const onLoad = useCallback(
     (map: google.maps.Map) => {
-      map.setOptions(createMapOptions());
+      map.setOptions(createMapOptions({ waterColor }));
 
       new google.maps.Marker({
         position: { lat: geolocation[0], lng: geolocation[1] },
@@ -38,7 +39,7 @@ export function FindUs({ geolocation, slug }: FindUsProps) {
         icon: `/events/${slug}/map-pin.png`,
       });
     },
-    [geolocation, slug]
+    [geolocation, slug, waterColor]
   );
 
   return (

--- a/src/data/events/index.ts
+++ b/src/data/events/index.ts
@@ -1,4 +1,4 @@
-[
+export const eventOrder = [
   "belgrade",
   "vienna",
   "london",
@@ -7,5 +7,5 @@
   "newyork",
   "charlotte",
   "newquay",
-  "london-on-the-thames"
-]
+  "london-on-the-thames",
+] as const;

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,40 +1,42 @@
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
 
+import { eventOrder } from "./events";
 import {
   EventDataCurrent,
   EventDataDefault,
   EventDataHistorical,
   EventDataJoined,
+  EventName,
 } from "./types";
 
 const dataDirectory = path.join(process.cwd(), "src/data");
 const eventsDirectory = path.join(dataDirectory, "events");
 
-export async function getEvents() {
-  return await fs.readdir(eventsDirectory);
+export function getEvents() {
+  return eventOrder;
 }
 
-export async function getEventYears(event: string) {
+export async function getEventYears(event: EventName) {
   return (await fs.readdir(path.join(eventsDirectory, event)))
     .map((fileName) => +fileName.replace(".json", ""))
     .filter(Boolean);
 }
 
 export async function getEventData(
-  event: string,
+  event: EventName,
   year: number
 ): Promise<EventDataHistorical>;
 export async function getEventData(
-  event: string,
+  event: EventName,
   year: "current"
 ): Promise<EventDataCurrent>;
 export async function getEventData(
-  event: string,
+  event: EventName,
   year: "default"
 ): Promise<EventDataDefault>;
 export async function getEventData(
-  event: string,
+  event: EventName,
   year: number | "current" | "default"
 ) {
   return JSON.parse(
@@ -45,7 +47,7 @@ export async function getEventData(
 }
 
 export async function getEventDataCurrentAndDefault(
-  slug: string
+  slug: EventName
 ): Promise<EventDataJoined> {
   const [currentData, defaultData] = await Promise.all([
     getEventData(slug, "current"),

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -7,7 +7,7 @@ import {
   EventDataDefault,
   EventDataHistorical,
   EventDataJoined,
-  EventName,
+  EventSlug,
 } from "./types";
 
 const dataDirectory = path.join(process.cwd(), "src/data");
@@ -17,26 +17,26 @@ export function getEvents() {
   return eventOrder;
 }
 
-export async function getEventYears(event: EventName) {
+export async function getEventYears(event: EventSlug) {
   return (await fs.readdir(path.join(eventsDirectory, event)))
     .map((fileName) => +fileName.replace(".json", ""))
     .filter(Boolean);
 }
 
 export async function getEventData(
-  event: EventName,
+  event: EventSlug,
   year: number
 ): Promise<EventDataHistorical>;
 export async function getEventData(
-  event: EventName,
+  event: EventSlug,
   year: "current"
 ): Promise<EventDataCurrent>;
 export async function getEventData(
-  event: EventName,
+  event: EventSlug,
   year: "default"
 ): Promise<EventDataDefault>;
 export async function getEventData(
-  event: EventName,
+  event: EventSlug,
   year: number | "current" | "default"
 ) {
   return JSON.parse(
@@ -47,7 +47,7 @@ export async function getEventData(
 }
 
 export async function getEventDataCurrentAndDefault(
-  slug: EventName
+  slug: EventSlug
 ): Promise<EventDataJoined> {
   const [currentData, defaultData] = await Promise.all([
     getEventData(slug, "current"),

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -82,12 +82,12 @@ export interface EventVideo {
 }
 
 export interface EventDataHistorical extends EventDataBase {
-  otherEvents?: Record<EventName, number[]>;
+  otherEvents?: Record<EventSlug, number[]>;
   videos?: EventVideo[];
 }
 
 export interface EventDataJoined extends EventDataCurrent, EventDataDefault {
-  slug: EventName;
+  slug: EventSlug;
 }
 
-export type EventName = (typeof eventOrder)[number];
+export type EventSlug = (typeof eventOrder)[number];

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,3 +1,5 @@
+import { eventOrder } from "./events";
+
 export interface SponsorData {
   href: string;
   name: string;
@@ -80,10 +82,12 @@ export interface EventVideo {
 }
 
 export interface EventDataHistorical extends EventDataBase {
-  otherEvents?: Record<string, number[]>;
+  otherEvents?: Record<EventName, number[]>;
   videos?: EventVideo[];
 }
 
 export interface EventDataJoined extends EventDataCurrent, EventDataDefault {
-  slug: string;
+  slug: EventName;
 }
+
+export type EventName = (typeof eventOrder)[number];

--- a/src/pages/[event]/[year]/index.tsx
+++ b/src/pages/[event]/[year]/index.tsx
@@ -11,6 +11,7 @@ import { Footer } from "~/components/Footer";
 import { SponsorStacksList } from "~/components/SponsorStacksList";
 import { Text } from "~/components/Text";
 import { VideoCard } from "~/components/VideoCard";
+import { EventName } from "~/data/types";
 
 import { getEventData, getEvents, getEventYears } from "../../../data";
 import { ReturnedParams, ReturnedProps } from "../../../utils";
@@ -104,13 +105,12 @@ export async function getStaticProps({
     getEventData(event, "default"),
     getEventData(event, +year),
   ]);
-
   const otherEvents = yearData.otherEvents
     ? await Promise.all(
         Object.entries(yearData.otherEvents).map(
           async ([event, otherYears]) => ({
-            event,
-            name: (await getEventData(event, "default")).name,
+            event: event as EventName,
+            name: (await getEventData(event as EventName, "default")).name,
             otherYears,
           })
         )
@@ -123,7 +123,7 @@ export async function getStaticProps({
 }
 
 export async function getStaticPaths() {
-  const events = await getEvents();
+  const events = getEvents();
   const eventYears = (
     await Promise.all(
       events.flatMap(async (event) =>

--- a/src/pages/[event]/[year]/index.tsx
+++ b/src/pages/[event]/[year]/index.tsx
@@ -11,7 +11,7 @@ import { Footer } from "~/components/Footer";
 import { SponsorStacksList } from "~/components/SponsorStacksList";
 import { Text } from "~/components/Text";
 import { VideoCard } from "~/components/VideoCard";
-import { EventName } from "~/data/types";
+import { EventSlug } from "~/data/types";
 
 import { getEventData, getEvents, getEventYears } from "../../../data";
 import { ReturnedParams, ReturnedProps } from "../../../utils";
@@ -109,8 +109,8 @@ export async function getStaticProps({
     ? await Promise.all(
         Object.entries(yearData.otherEvents).map(
           async ([event, otherYears]) => ({
-            event: event as EventName,
-            name: (await getEventData(event as EventName, "default")).name,
+            event: event as EventSlug,
+            name: (await getEventData(event as EventSlug, "default")).name,
             otherYears,
           })
         )

--- a/src/pages/[event]/faqs.tsx
+++ b/src/pages/[event]/faqs.tsx
@@ -44,10 +44,10 @@ export async function getStaticProps({
   };
 }
 
-export async function getStaticPaths() {
+export function getStaticPaths() {
   return {
     fallback: false,
-    paths: (await getEvents()).map((event) => ({
+    paths: getEvents().map((event) => ({
       params: { event },
     })),
   };

--- a/src/pages/[event]/index.tsx
+++ b/src/pages/[event]/index.tsx
@@ -7,7 +7,7 @@ import { BannerText } from "~/components/BannerText";
 import { EventFooter } from "~/components/EventFooter";
 import { EventHeader } from "~/components/EventHeader";
 import { EventSummary } from "~/components/EventSummary";
-import { EventTheme } from "~/components/EventTheme";
+import { EventColors, EventTheme } from "~/components/EventTheme";
 import { ExpectationPhotos } from "~/components/ExpectationPhotos";
 import { FindUs } from "~/components/FindUs";
 import { SecondaryBanner } from "~/components/SecondaryBanner";
@@ -36,6 +36,7 @@ export default function Event({
     year,
   },
 }: ReturnedProps<typeof getStaticProps>) {
+  const eventColors = EventColors({ event: slug });
   return (
     <EventTheme event={slug}>
       <Head>
@@ -116,7 +117,13 @@ export default function Event({
 
       {sponsors && <SponsorStacksList {...sponsors} slug={slug} />}
 
-      {geolocation && <FindUs geolocation={geolocation} slug={slug} />}
+      {geolocation && (
+        <FindUs
+          geolocation={geolocation}
+          slug={slug}
+          waterColor={eventColors["color-backdrop-subtle"]}
+        />
+      )}
 
       <EventFooter slug={slug} />
     </EventTheme>

--- a/src/pages/[event]/index.tsx
+++ b/src/pages/[event]/index.tsx
@@ -7,7 +7,7 @@ import { BannerText } from "~/components/BannerText";
 import { EventFooter } from "~/components/EventFooter";
 import { EventHeader } from "~/components/EventHeader";
 import { EventSummary } from "~/components/EventSummary";
-import { EventColors, EventTheme } from "~/components/EventTheme";
+import { EventTheme } from "~/components/EventTheme";
 import { ExpectationPhotos } from "~/components/ExpectationPhotos";
 import { FindUs } from "~/components/FindUs";
 import { SecondaryBanner } from "~/components/SecondaryBanner";
@@ -36,7 +36,6 @@ export default function Event({
     year,
   },
 }: ReturnedProps<typeof getStaticProps>) {
-  const eventColors = EventColors({ event: slug });
   return (
     <EventTheme event={slug}>
       <Head>
@@ -117,13 +116,7 @@ export default function Event({
 
       {sponsors && <SponsorStacksList {...sponsors} slug={slug} />}
 
-      {geolocation && (
-        <FindUs
-          geolocation={geolocation}
-          slug={slug}
-          waterColor={eventColors["color-backdrop-subtle"]}
-        />
-      )}
+      {geolocation && <FindUs geolocation={geolocation} slug={slug} />}
 
       <EventFooter slug={slug} />
     </EventTheme>
@@ -140,10 +133,10 @@ export async function getStaticProps({
   };
 }
 
-export async function getStaticPaths() {
+export function getStaticPaths() {
   return {
     fallback: false,
-    paths: (await getEvents()).map((event) => ({
+    paths: getEvents().map((event) => ({
       params: { event },
     })),
   };

--- a/src/pages/[event]/schedule.tsx
+++ b/src/pages/[event]/schedule.tsx
@@ -38,10 +38,10 @@ export async function getStaticProps({
   };
 }
 
-export async function getStaticPaths() {
+export function getStaticPaths() {
   return {
     fallback: false,
-    paths: (await getEvents()).map((event) => ({
+    paths: getEvents().map((event) => ({
       params: { event },
     })),
   };

--- a/src/pages/[event]/spon.tsx
+++ b/src/pages/[event]/spon.tsx
@@ -78,10 +78,10 @@ export async function getStaticProps({
   };
 }
 
-export async function getStaticPaths() {
+export function getStaticPaths() {
   return {
     fallback: false,
-    paths: (await getEvents()).map((event) => ({
+    paths: getEvents().map((event) => ({
       params: { event },
     })),
   };

--- a/src/pages/[event]/tickets.tsx
+++ b/src/pages/[event]/tickets.tsx
@@ -41,10 +41,10 @@ export async function getStaticProps({
   };
 }
 
-export async function getStaticPaths() {
+export function getStaticPaths() {
   return {
     fallback: false,
-    paths: (await getEvents()).map((event) => ({
+    paths: getEvents().map((event) => ({
       params: { event },
     })),
   };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,7 @@ import { EventsList } from "~/components/Index/EventsList";
 import { Intro } from "~/components/Index/Intro";
 import { Newsletter } from "~/components/Index/Newsletter";
 import { SponsorStacksList } from "~/components/SponsorStacksList";
+import { eventOrder } from "~/data/events";
 
 import { getEventDataCurrentAndDefault } from "../data";
 import { ReturnedProps } from "../utils";
@@ -34,10 +35,9 @@ export default function Index({
 }
 
 export async function getStaticProps() {
-  const eventsOrder = (await import("~/data/events.json")).default;
   return {
     props: {
-      events: await Promise.all(eventsOrder.map(getEventDataCurrentAndDefault)),
+      events: await Promise.all(eventOrder.map(getEventDataCurrentAndDefault)),
       sponsors: (await import("~/data/sponsors.json")).default,
     },
   };

--- a/src/pages/pastevents/index.tsx
+++ b/src/pages/pastevents/index.tsx
@@ -57,7 +57,7 @@ export default function PastEvents({
 }
 
 export async function getStaticProps() {
-  const events = await getEvents();
+  const events = getEvents();
   const eventsData = await Promise.all(
     events.map(async (event) => {
       const [defaultData, years] = await Promise.all([

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,6 +1,6 @@
-import { EventName } from "~/data/types";
+import { EventSlug } from "~/data/types";
 
-export function getProspectusUri(slug: EventName, year: number) {
+export function getProspectusUri(slug: EventSlug, year: number) {
   return `/assets/HalfStack${uppercaseFirst(slug)}${year}Prospectus.pdf`;
 }
 

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -1,4 +1,6 @@
-export function getProspectusUri(slug: string, year: number) {
+import { EventName } from "~/data/types";
+
+export function getProspectusUri(slug: EventName, year: number) {
   return `/assets/HalfStack${uppercaseFirst(slug)}${year}Prospectus.pdf`;
 }
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to halfstackconf-next! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #16 
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/halfstackconf-next/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/halfstackconf-next/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

FindUs' Google Map embed's water color now matches the event's theme

Attempted getComputedStyles on a throw-away div created with document.createElement, but didn't have any luck and it broke SSR:

```
const div = document.CreateElement("div")
div.classList.add(styles[event])
document.getComputedStyles(div)
```

Instead, this PR pulls those variables into JS. Not sure if there is a better way to do this.